### PR TITLE
bump up the badge version to 0.81.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [discord-url]: https://discord.gg/NtAbbGn
 [ci-badge]: https://github.com/nushell/nufmt/actions/workflows/main.yml/badge.svg
 [ci-url]: https://github.com/nushell/nufmt/actions/workflows/main.yml
-[nushell-badge]: https://img.shields.io/badge/nushell-v0.80.0-green
+[nushell-badge]: https://img.shields.io/badge/nushell-v0.81.0-green
 [nushell-url]: https://crates.io/crates/nu
 
 </div>


### PR DESCRIPTION
now that the `0.81.0` release is out, we should probably have the correct version between the Nushell badged and the link to the `nu` crate :yum: 

cc/ @AucaCoyan 