### PR TITLE
add a Nushell version update script and bump all versions to `0.81.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,48 +733,44 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5a63e1a390ceafa336ac4332724502a478b5dec2f67b24fd1d19fcd4d019b0"
+checksum = "4235fe928b81457e353959b51f7789bbbd5f0bc581281a4d23894f512842718d"
 dependencies = [
- "chrono",
  "nu-glob",
  "nu-path",
  "nu-protocol",
  "nu-utils",
- "serde",
  "sysinfo",
 ]
 
 [[package]]
 name = "nu-glob"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922b20eb03387d5aa1d41bc9dbdd47799648c5417a0632328b3e367cb035b31f"
+checksum = "6a413281323e07a2367c7fdbf2e4afa4c941349df4e6bf3d937d6888eb39e28d"
 
 [[package]]
 name = "nu-parser"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b08bff634f103a958b184d7664207271a9a99ffc9a45b80709c71c1af5d2e63"
+checksum = "ef1e339b58cf9c0dea3fd769075454a46bbabdd074bc35d5815eefbc4e039711"
 dependencies = [
  "bytesize",
  "chrono",
  "itertools",
  "log",
- "miette",
  "nu-engine",
  "nu-path",
  "nu-protocol",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "nu-path"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109b3cb16c1f1a134b19f63aa7d633af5f0ec61f25c5cb96e0f775c3794e9773"
+checksum = "2906ffcb3924486695884b229d31ea812316c3332c99644d461c1b2b07868ab0"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -783,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7943cef88db9b614326b924125a7342e1a46e4eb9e82547becf917765f62d4"
+checksum = "55622cd4b1f4bfb3d1ed7f8d935bc40e818ab16a07c34c217085aa42754bca67"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -800,16 +796,15 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "sys-locale",
  "thiserror",
  "typetag",
 ]
 
 [[package]]
 name = "nu-utils"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da43579f039c9428df85f28fc58c4b1732ba2a7a9971c1b56dbe39b0a8e8ac3"
+checksum = "163536ef0adb8f8c66d168aa018a7bb66a6c8174a5e805f6e30ebd2aed33f47c"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -1174,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
+checksum = "9557d0845b86eea8182f7b10dff120214fb6cd9fd937b6f4917714e546a38695"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = "1.0.71"
 clap = { version = "4.3.0", optional = true, features = ["unicode", "derive"] }
 env_logger = "0.10.0"
 log = "0.4.17"
-nu-parser = "0.80.0"
-nu-protocol = "0.80.0"
+nu-parser = "0.81.0"
+nu-protocol = "0.81.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [discord-url]: https://discord.gg/NtAbbGn
 [ci-badge]: https://github.com/nushell/nufmt/actions/workflows/main.yml/badge.svg
 [ci-url]: https://github.com/nushell/nufmt/actions/workflows/main.yml
-[nushell-badge]: https://img.shields.io/badge/nushell-v0.80.0-green
+[nushell-badge]: https://img.shields.io/badge/nushell-v0.81.0-green
 [nushell-url]: https://crates.io/crates/nu
 
 </div>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [discord-url]: https://discord.gg/NtAbbGn
 [ci-badge]: https://github.com/nushell/nufmt/actions/workflows/main.yml/badge.svg
 [ci-url]: https://github.com/nushell/nufmt/actions/workflows/main.yml
-[nushell-badge]: https://img.shields.io/badge/nushell-v0.81.0-green
+[nushell-badge]: https://img.shields.io/badge/nushell-v0.80.0-green
 [nushell-url]: https://crates.io/crates/nu
 
 </div>

--- a/scripts/update-nushell-version
+++ b/scripts/update-nushell-version
@@ -1,0 +1,19 @@
+#!/usr/bin/env nu
+
+use std log
+
+def main [
+    version: string  # the new version of Nushell, e.g. 0.82.0
+] {
+    log info "updating the badge in the README"
+    open README.md
+    | str replace 'https://img.shields.io/badge/nushell-v\d+\.\d+\.\d+-green' $"https://img.shields.io/badge/nushell-v($version)-green"
+    | save --force README.md
+
+    log info "updating the `nu-parser` dependency"
+    cargo add $"nu-parser@($version)"
+    log info "updating the `nu-protocol` dependency"
+    cargo add $"nu-protocol@($version)"
+
+    log warning "do not forget to commit and push this :wink:"
+}


### PR DESCRIPTION
related to
> Thanks for the PR!
> You forgot to update the dependencies 🥈  lol
>
>Don't worry, I am going to pump the dependencies after this #18
>
_Originally posted by @AucaCoyan in https://github.com/nushell/nufmt/issues/20#issuecomment-1583078158_

ok so i've written a script to automate the process of changing the version of `nushell/nufmt` to avoid ending up in the same situation as in #20 :grimacing: 