### PR TITLE
refactor the tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,8 @@ mod test {
         assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 
-    // comments aren't a part of Spans,
-    // we need another way of reading a skipping comments
-    // otherwise the nufmt directly remove them.
     #[test]
-    #[ignore]
+    #[ignore = "comments aren't a part of Spans,"]
     fn ignore_comments() {
         let nu = String::from("# this is a comment");
         let expected = String::from("# this is a comment");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ mod test {
 
     #[test]
     fn array_of_object() {
-        let expected = String::from("[{\"a\":0},{},{\"a\":null}]\n");
         let nu = String::from(
             "[
   {
@@ -61,6 +60,7 @@ mod test {
   }
 ]",
         );
+        let expected = String::from("[{\"a\":0},{},{\"a\":null}]\n");
         assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,14 @@ mod test {
 
     #[test]
     fn echoes_primitive() {
-        let nu = String::from("1.35\n");
-        assert_eq!(nu, format_string(&nu, &Config::default()));
+        let nu = String::from("1.35");
+        let expected = String::from("1.35\n");
+        assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 
     #[test]
     fn handle_escaped_strings() {
-        let nu = String::from("  \"hallo\\\"\" \n");
+        let nu = String::from("  \"hallo\\\"\"");
         let expected = String::from("\"hallo\\\"\"\n");
         assert_eq!(expected, format_string(&nu, &Config::default()));
     }
@@ -87,8 +88,9 @@ mod test {
 
     #[test]
     fn ignore_whitespace_in_string() {
-        let nu = String::from("\" hallo \"\n");
-        assert_eq!(nu, format_string(&nu, &Config::default()));
+        let nu = String::from("\" hallo \"");
+        let expected = String::from("\" hallo \"\n");
+        assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,8 @@ mod test {
 
     #[test]
     fn handle_escaped_strings() {
-        let nu = String::from("  \" hallo \\\" \" \n");
-        let expected = String::from("\" hallo \\\" \"\n");
+        let nu = String::from("  \"hallo\\\"\" \n");
+        let expected = String::from("\"hallo\\\"\"\n");
         assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 


### PR DESCRIPTION
cc/ @AucaCoyan 

i was having a look at the tests and wanted to give a go at
- understanding them
- refactoring them a bit for later ease of maintainance hopefully
:relieved: 

in this PR, i've
- moved the "ignore" comment to the "reason" of the `ignore` clause in the `ignore_comments` test
- removed whitespaces from `handle_escaped_strings` because `ignore_whitespace_in_string` already tests this
- made the `expected` part of the `assert`s explicit
- put `expected` always after `nu`, for consistency

i hope you'll find that somewhat better :crossed_fingers: 

:question: @AucaCoyan, i've got a question :smirk:
in all the tests, the input string does not have a newline at the end, whereas the output of `nufmt` does. it is by design?