### PR TITLE
refactor the tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,16 @@ pub fn format_string(input_string: &String, config: &Config) -> String {
 mod test {
     use super::*;
 
+    fn run_test(input: &str, expected: &str) {
+        assert_eq!(
+            expected.to_string(),
+            format_string(&input.to_string(), &Config::default())
+        );
+    }
+
     #[test]
     fn array_of_object() {
-        let nu = String::from(
-            "[
+        let input = "[
   {
     \"a\": 0
   },
@@ -57,30 +63,28 @@ mod test {
   {
     \"a\": null
   }
-]",
-        );
-        let expected = String::from("[{\"a\":0},{},{\"a\":null}]\n");
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+]";
+        let expected = "[{\"a\":0},{},{\"a\":null}]\n";
+        run_test(input, expected);
     }
 
     #[test]
     fn echoes_primitive() {
-        let nu = String::from("1.35");
-        let expected = String::from("1.35\n");
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+        let input = "1.35";
+        let expected = "1.35\n";
+        run_test(input, expected);
     }
 
     #[test]
     fn handle_escaped_strings() {
-        let nu = String::from("  \"hallo\\\"\"");
-        let expected = String::from("\"hallo\\\"\"\n");
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+        let input = "  \"hallo\\\"\"";
+        let expected = "\"hallo\\\"\"\n";
+        run_test(input, expected);
     }
 
     #[test]
     fn ignore_comments() {
-        let nu = String::from(
-            "# beginning of script comment
+        let input = "# beginning of script comment
 
 let one = 1
 def my-func [
@@ -96,32 +100,29 @@ myfunc(one)
 # final comment
 
 
-",
-        );
-        let expected = String::from(
-            "# beginning of script comment
+";
+        let expected = "# beginning of script comment
 let one = 1
 def my-func [
     param1:int # inline comment
 ]{ print(param1) 
 }
 myfunc(one) 
-# final comment\n",
-        );
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+# final comment\n";
+        run_test(input, expected);
     }
 
     #[test]
     fn ignore_whitespace_in_string() {
-        let nu = String::from("\" hallo \"");
-        let expected = String::from("\" hallo \"\n");
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+        let input = "\" hallo \"";
+        let expected = "\" hallo \"\n";
+        run_test(input, expected);
     }
 
     #[test]
     fn remove_leading_whitespace() {
-        let nu = String::from("   0");
-        let expected = String::from("0\n");
-        assert_eq!(expected, format_string(&nu, &Config::default()));
+        let input = "   0";
+        let expected = "0\n";
+        run_test(input, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,34 @@ mod test {
     #[test]
     fn ignore_comments() {
         let nu = String::from(
-            "# beginning of script comment\n\n let one = 1\ndef my-func [\n    param1:int # inline comment\n]{ print(param1) \n}\nmyfunc(one)\n\n\n\n\n\n# final comment\n\n\n");
+            "# beginning of script comment
+
+let one = 1
+def my-func [
+    param1:int # inline comment
+]{ print(param1) 
+}
+myfunc(one)
+
+
+
+
+
+# final comment
+
+
+",
+        );
         let expected = String::from(
-            "# beginning of script comment\nlet one = 1\ndef my-func [\n    param1:int # inline comment\n]{ print(param1) \n}\nmyfunc(one) \n# final comment\n");
+            "# beginning of script comment
+let one = 1
+def my-func [
+    param1:int # inline comment
+]{ print(param1) 
+}
+myfunc(one) 
+# final comment\n",
+        );
         assert_eq!(expected, format_string(&nu, &Config::default()));
     }
 


### PR DESCRIPTION
cc/ @AucaCoyan 

did you know i like refactoring things? :smirk: 

in this PR, i propose
- breaking the multi-line `ignore_comments` test into multiple lines => this makes the whole structure easier to see imo, e.g. the fact that `nufmt` adds a trailing whitespace after `myfunc(one)`
> **Warning**
> also we have to keep in mind that `nufmt` works just fine with invalid `nu` code, e.g. `ignore_comments` is not valid `nu` code :thinking: 
- renaming `nu` into `input` in the tests to test `nufmt(input) == expected`
- writing a `run_test` wrapper that calls `nufmt` and `assert` the values