### PR TITLE
Make direnv more compatible

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,11 @@
-use flake
+# If nix is installed hook into it.
+if [ $(which nix) ]
+then
+    use flake
+fi
+
+# If nu is the current shell use toolkit.nu
+if [ $(echo $SHELL) == $(which nu) ]
+then    
+    nu -e "use toolkit.nu"
+fi


### PR DESCRIPTION
## Description of changes

<!-- What changes did you make -->
Direnv now checks if you have nix installed before trying to load the env.
It also checks if you are using nushell and will use the toolkit

## Relevant Issues
- should supersede #50 