### PR TITLE
Actually read from stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
 
     let exit_code = match cli.files[..] {
         [] if cli.stdin => {
-            let stdin_input = io::stdin().lines().map(|x| x.unwrap()).collect::<String>();
+            let stdin_input = io::stdin().lines().map(|x| x.unwrap()).collect();
             format_string(Some(stdin_input), &cli_config)
         }
         _ => format_files(cli.files, &cli_config),


### PR DESCRIPTION
## Description of changes

`--stdin` flag read a command line argument, not stdin. Now it reads from stdin.

Not sure if my code would compile on windows, but I don't have a windows computer to test it.

I'm aware that https://github.com/nushell/nufmt/pull/57 tries to solve this as well, but it seems stagnant and won't pass CI.

## Relevant Issues

https://github.com/nushell/nufmt/issues/56
