### PR TITLE
Fix DeclIds

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -14,10 +14,10 @@ struct DeclId;
 
 #[allow(non_upper_case_globals)]
 impl DeclId {
-    const If: usize = 22;
-    const Let: usize = 30;
     const Def: usize = 5;
-    const ExportDefEnv: usize = 6;
+    const ExportDefEnv: usize = 13;
+    const If: usize = 21;
+    const Let: usize = 28;
 }
 
 fn get_engine_state() -> EngineState {
@@ -183,7 +183,6 @@ fn write_only_if_have_hastag_or_equal(
 fn resolve_call(c_bytes: &[u8], declid: usize, mut out: Vec<u8>) -> Vec<u8> {
     out = match declid {
         DeclId::If => insert_newline(out),
-        DeclId::Let => insert_newline(out),
         DeclId::Def => insert_newline(out),
         DeclId::ExportDefEnv | _ => out,
     };

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -20,15 +20,6 @@ impl<'a> NewDeclId<'a> {
         NewDeclId { decls }
     }
 
-    pub fn get_decl_id(&self, decl_name: &str) -> Option<usize> {
-        let decl_name_utf8 = decl_name.as_bytes().to_vec();
-        for decl in self.decls {
-            if decl_name_utf8 == decl.0 {
-                return Some(decl.1.get());
-            }
-        }
-        None
-    }
     pub fn get_decl_name(&'a self, decl_id: usize) -> Option<&'a str> {
         for decl in self.decls {
             if decl_id == decl.1.get() {
@@ -50,7 +41,6 @@ pub(crate) fn format_inner(contents: &[u8], _config: &Config) -> Vec<u8> {
     let engine_state = get_engine_state();
     let decls_sorted: Vec<(Vec<u8>, nu_protocol::Id<nu_protocol::marker::Decl>)> =
         engine_state.get_decls_sorted(false);
-    //dbg!(&decls_sorted);
 
     let decl_ids = NewDeclId::new(&decls_sorted);
 


### PR DESCRIPTION
## Description of changes

**What I was trying to improve**
- decl ids used for keywords like "let", "if" etc... were defined statically, whereas they are generated dynamically in nushell. So the hard coded ids were very likely to become invalid every time we update nu.
- Some of the hard coded ids currently used were actually already wrong!

**After my changes**:
- The code now gets the decl names by id without the need for hard coded values
- Thus we use the right ones

The tests still pass.

Friendly reminder that's I'm still quite new to Rust, but eager to improve, so any improvement suggestion is more than welcome :)

## Relevant Issues
None