### PR TITLE
fix: nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,8 +38,8 @@
                const VALID: &str = "# beginning of script comment
                let one = 1
                ";
-              -const TEST_BINARY: &'static str = "target/debug/nufmt";
-              +const TEST_BINARY: &'static str = "target/@target_triple@/release/nufmt";
+              -const TEST_BINARY: &str = "target/debug/nufmt";
+              +const TEST_BINARY: &str = "target/@target_triple@/release/nufmt";
 
                #[test]
                fn failure_with_invalid_config() {


### PR DESCRIPTION
Patch never applies, the code in the repo doesn't match the patch.

```
error: builder for '/nix/store/h66ffisgy216shs79wn8ca7nvm6imylw-nufmt.drv' failed with exit code 1;
       last 10 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/9waf3yvwcq8yp0ak03qzz5wq9pvkq604-ygdji3y8jsyq71pww9c8pwwncwd0kwz4-source
       > source root is ygdji3y8jsyq71pww9c8pwwncwd0kwz4-source
       > Executing cargoSetupPostUnpackHook
       > Finished cargoSetupPostUnpackHook
       > Running phase: patchPhase
       > applying patch /nix/store/l7ydv4ifncszmaha510nfr2zwn7l56yq-1fgjm3xfpm6v4irkfrb3pjy9c5zw8l40-integration-tests-nix-fix.patch
       > patching file tests/main.rs
       > Hunk #1 FAILED at 8.
       > 1 out of 1 hunk FAILED -- saving rejects to file tests/main.rs.rej
```
## Description of changes

<!-- What changes did you make -->

## Relevant Issues

<!-- Eg. #43 -->
