### PR TITLE
don't break inline param comment formatting

### DIFF
--- a/tests/fixtures/expected/inline_param_comment.nu
+++ b/tests/fixtures/expected/inline_param_comment.nu
@@ -1,0 +1,3 @@
+def fun1 [
+  text: string # param comment
+  ] { $text }

--- a/tests/fixtures/input/inline_param_comment.nu
+++ b/tests/fixtures/input/inline_param_comment.nu
@@ -1,0 +1,3 @@
+def fun1 [
+  text: string # param comment
+  ] { $text }

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -736,3 +736,15 @@ fn issue76_test() {
     let test_binary = get_test_binary();
     run_ground_truth_test(&test_binary, "issue76");
 }
+
+#[test]
+fn ground_truth_inline_param_comment_issue77() {
+    let test_binary = get_test_binary();
+    run_ground_truth_test(&test_binary, "inline_param_comment");
+}
+
+#[test]
+fn idempotency_inline_param_comment_issue77() {
+    let test_binary = get_test_binary();
+    run_idempotency_test(&test_binary, "inline_param_comment");
+}


### PR DESCRIPTION
## Description of changes

This PR tries to fix the inline parameter comment formatting identified in #77 

Closes #77 
