### PR TITLE
Remove `cargo install nufmt` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@
 cargo install --git https://github.com/nushell/nufmt
 ```
 
-### Using Cargo
-
-```bash
-cargo install nufmt
-```
-
 ### Using Nix
 
 ```bash


### PR DESCRIPTION
The project's `README.md` suggests installing `nufmt` from crates.io with `cargo install nufmt`, but nufmt is not currently published to crates.io, and there are no immediate plans to publish it (see #62).

Trying to follow that suggestion results in:

```shell
~> cargo install nufmt
    Updating crates.io index
error: could not find `nufmt` in registry `crates-io` with version `*`
```

I think it's better to remove the suggestion for now, and restore it when nufmt gets published to crates.io.

## Description of changes

Removed the section showing the non-working installation method.

## Relevant Issues

https://github.com/nushell/nufmt/issues/62