### PR TITLE
fix: prevent stripping parens in boolean expressions (#162)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
 
             # Not included in the package dependencies, but used for development
             rust-analyzer
+            rustfmt
           ];
         };
 

--- a/src/formatting/mod.rs
+++ b/src/formatting/mod.rs
@@ -351,6 +351,10 @@ fn normalize_redundant_assignment_pipeline_parens(line: &str) -> String {
         return line.to_string();
     }
 
+    if rhs.contains(") and (") || rhs.contains(") or (") {
+        return line.to_string();
+    }
+
     let lhs = line[..eq_idx].trim_end();
     format!("{lhs} = {inner}")
 }

--- a/tests/fixtures/expected/parens_stripping_boolean_exprs_issue162.nu
+++ b/tests/fixtures/expected/parens_stripping_boolean_exprs_issue162.nu
@@ -1,0 +1,1 @@
+let has_update: bool = ($update_val != null) and ($update_val | is-not-empty)

--- a/tests/fixtures/input/parens_stripping_boolean_exprs_issue162.nu
+++ b/tests/fixtures/input/parens_stripping_boolean_exprs_issue162.nu
@@ -1,0 +1,1 @@
+let has_update: bool = ($update_val != null)   and  ($update_val | is-not-empty)

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -605,4 +605,9 @@ fixture_tests!(
         ground_truth_closure_argument_pipe_spacing_normalized_issue160,
         idempotency_closure_argument_pipe_spacing_normalized_issue160
     ),
+    (
+        "parens_stripping_boolean_exprs_issue162",
+        ground_truth_parens_stripping_boolean_exprs_issue162,
+        idempotency_parens_stripping_boolean_exprs_issue162
+    ),
 );


### PR DESCRIPTION
## Description of changes

Fixes incorrect stripping of leading and trailing parentheses in boolean expressions (e.g., `let var = (a) and (b)`) where they were mistakenly treated as a single matching pair.

## Relevant Issues

closes #162
