### PR TITLE
fix: preserve parentheses in if-call expressions and add related tests

### DIFF
--- a/src/formatting/expressions.rs
+++ b/src/formatting/expressions.rs
@@ -253,8 +253,12 @@ impl<'a> Formatter<'a> {
                 return;
             }
 
-            let can_drop_parens =
-                block.pipelines.len() == 1 && block.pipelines[0].elements.len() == 1;
+            let can_drop_parens = block.pipelines.len() == 1
+                && block.pipelines[0].elements.len() == 1
+                && !matches!(
+                    block.pipelines[0].elements[0].expr.expr,
+                    Expr::Call(_) | Expr::ExternalCall(_, _)
+                );
             if can_drop_parens && !self.subexpr_preceded_by_not(span.start) {
                 self.format_block(block);
                 return;

--- a/tests/fixtures/expected/if_call_parentheses_preserved_after_if_issue176.nu
+++ b/tests/fixtures/expected/if_call_parentheses_preserved_after_if_issue176.nu
@@ -1,0 +1,11 @@
+def is-wayland [] { $env.WAYLAND_DISPLAY? != null }
+
+if (is-wayland) {
+    print "wayland"
+}
+
+if not (is-wayland) {
+    print "not wayland"
+} else if (is-wayland) {
+    print "else wayland"
+}

--- a/tests/fixtures/input/if_call_parentheses_preserved_after_if_issue176.nu
+++ b/tests/fixtures/input/if_call_parentheses_preserved_after_if_issue176.nu
@@ -1,0 +1,11 @@
+def is-wayland [] { $env.WAYLAND_DISPLAY? != null }
+
+if (is-wayland) {
+    print "wayland"
+}
+
+if not (is-wayland) {
+    print "not wayland"
+} else if (is-wayland) {
+    print "else wayland"
+}

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -659,4 +659,9 @@ fixture_tests!(
         ground_truth_unary_not_condition_keeps_required_subexpression_parens_issue172,
         idempotency_unary_not_condition_keeps_required_subexpression_parens_issue172
     ),
+    (
+        "if_call_parentheses_preserved_after_if_issue176",
+        ground_truth_if_call_parentheses_preserved_after_if_issue176,
+        idempotency_if_call_parentheses_preserved_after_if_issue176
+    ),
 );


### PR DESCRIPTION
## Description of changes

Yet another attempt at fixing #172 and #176

## Relevant Issues

closes #172 
closes #176
