### PR TITLE
fix: typo after formatting single file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -319,6 +319,8 @@ impl FormattingStats {
         if self.reformatted > 0 {
             let msg = if check_mode {
                 "would be reformatted"
+            } else if self.reformatted == 1 {
+                "was formatted"
             } else {
                 "were formatted"
             };


### PR DESCRIPTION
## Description of changes

Added a branch for the case where a single file was formatted.

`1 file were formatted` -> `1 file was formatted`