### PR TITLE
fix: preserve curly braces around `export module` blocks (#185)

### DIFF
--- a/src/formatting/calls.rs
+++ b/src/formatting/calls.rs
@@ -15,7 +15,7 @@ use nu_utils::NuCow;
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Commands whose block arguments are formatted specially.
-pub(super) const BLOCK_COMMANDS: &[&str] = &["for", "while", "loop", "module"];
+pub(super) const BLOCK_COMMANDS: &[&str] = &["for", "while", "loop", "module", "export module"];
 pub(super) const CONDITIONAL_COMMANDS: &[&str] = &["if", "try"];
 pub(super) const DEF_COMMANDS: &[&str] = &["def", "def-env", "export def"];
 pub(super) const EXTERN_COMMANDS: &[&str] = &["extern", "export extern"];

--- a/tests/fixtures/expected/export.nu
+++ b/tests/fixtures/expected/export.nu
@@ -3,3 +3,7 @@ export def bar [x: int] { $x * 2 }
 export def add [a: int, b: int] { $a + $b }
 export alias ll = ls -l
 export alias la = ls -a
+
+export module mymod {
+    export def baz [] { 0 }
+}

--- a/tests/fixtures/input/export.nu
+++ b/tests/fixtures/input/export.nu
@@ -3,3 +3,7 @@ export def bar   [x:  int]   {  $x  *  2  }
 export def add  [a:  int,  b:  int]   {  $a  +  $b  }
 export alias ll   =   ls -l
 export alias la  =   ls -a
+
+export module    mymod    {
+export def   baz   [] {  0}
+}


### PR DESCRIPTION
## Description of changes

- Added `"export module"` to the `BLOCK_COMMANDS` in `calls.rs`
- Added an `export module` block to the `export.nu` test fixture

## Relevant Issues

closes #185
