### PR TITLE
fix side-comments, add tabs or spaces functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "nufmt"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nufmt"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["The NuShell Contributors"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Create a `nufmt.nuon` file in your project root:
 ```nuon
 {
     indent: 4
+    indent_char: "space"
     line_length: 80
     margin: 1
     exclude: ["vendor/**", "target/**"]
@@ -120,7 +121,8 @@ Configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `indent` | int | 4 | Number of spaces per indentation level |
+| `indent` | int | 4 | Number of indentation characters per level |
+| `indent_char` | string | `"space"` | Indentation character: `"space"` or `"tab"` |
 | `line_length` | int | 80 | Maximum line length (advisory) |
 | `margin` | int | 1 | Number of blank lines between top-level items |
 | `exclude` | list\<string\> | [] | Glob patterns for files to exclude |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Configuration options:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `indent` | int | 4 | Number of indentation characters per level |
+| `indent` | int | 4 | Visual indentation width per level (tab width when `indent_char = "tab"`) |
 | `indent_char` | string | `"space"` | Indentation character: `"space"` or `"tab"` |
 | `line_length` | int | 80 | Maximum line length (advisory) |
 | `margin` | int | 1 | Number of blank lines between top-level items |

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,11 @@ pub enum IndentChar {
 /// Configuration options for the formatter
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
-    /// Number of spaces per indentation level (default: 4).
+    /// Visual indentation width per level (default: 4).
+    ///
+    /// With `indent_char = "space"`, this is the number of spaces written.
+    /// With `indent_char = "tab"`, this is the virtual tab width used in
+    /// layout calculations while writing one tab per indentation level.
     pub indent: usize,
     /// Character used for each indentation unit (`space` or `tab`).
     pub indent_char: IndentChar,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,11 +5,20 @@ use std::convert::TryFrom;
 use crate::config_error::ConfigError;
 use nu_protocol::Value;
 
+/// Character used for indentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndentChar {
+    Space,
+    Tab,
+}
+
 /// Configuration options for the formatter
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     /// Number of spaces per indentation level (default: 4).
     pub indent: usize,
+    /// Character used for each indentation unit (`space` or `tab`).
+    pub indent_char: IndentChar,
     /// Maximum line length before wrapping (default: 80).
     pub line_length: usize,
     /// Number of blank lines to insert between top-level definitions (default: 1).
@@ -28,6 +37,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             indent: 4,
+            indent_char: IndentChar::Space,
             line_length: 80,
             margin: 1,
             margin_is_explicit: false,
@@ -44,6 +54,7 @@ impl Config {
     pub fn new(tab_spaces: usize, max_width: usize, margin: usize) -> Self {
         Self {
             indent: tab_spaces,
+            indent_char: IndentChar::Space,
             line_length: max_width,
             margin,
             margin_is_explicit: true,
@@ -69,6 +80,7 @@ impl TryFrom<Value> for Config {
         for (key, value) in record.iter() {
             match key.as_str() {
                 "indent" => config.indent = parse_positive_int(key, value)?,
+                "indent_char" => config.indent_char = parse_indent_char(value)?,
                 "line_length" => config.line_length = parse_positive_int(key, value)?,
                 "margin" => {
                     config.margin = parse_non_negative_int(key, value)?;
@@ -120,6 +132,27 @@ fn parse_positive_int(key: &str, value: &Value) -> Result<usize, ConfigError> {
 /// Parse a value as a non-negative integer (must be `>= 0`).
 fn parse_non_negative_int(key: &str, value: &Value) -> Result<usize, ConfigError> {
     parse_int_at_least(key, value, 0, "a non-negative number")
+}
+
+/// Parse a value as the indentation character.
+fn parse_indent_char(value: &Value) -> Result<IndentChar, ConfigError> {
+    let Value::String { val, .. } = value else {
+        return Err(ConfigError::InvalidOptionType(
+            "indent_char".to_string(),
+            value.get_type().to_string(),
+            "string",
+        ));
+    };
+
+    match val.as_str() {
+        "space" => Ok(IndentChar::Space),
+        "tab" => Ok(IndentChar::Tab),
+        _ => Err(ConfigError::InvalidOptionValue(
+            "indent_char".to_string(),
+            val.clone(),
+            "space or tab",
+        )),
+    }
 }
 
 /// Parse a `Value` as a `list<string>` and return the strings.

--- a/src/formatting/calls.rs
+++ b/src/formatting/calls.rs
@@ -164,7 +164,7 @@ impl<'a> Formatter<'a> {
             return false;
         }
 
-        source_span.len() > self.config.line_length
+        source_span.len() + (self.config.indent * self.indent_level) > self.config.line_length
     }
 
     /// Format a long regular call as:
@@ -1111,7 +1111,7 @@ impl<'a> Formatter<'a> {
                 .sum::<usize>()
             + sig.required_positional.len().saturating_sub(1) * 2;
 
-        inline_len <= self.config.line_length
+        inline_len + (self.config.indent * self.indent_level) <= self.config.line_length
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/formatting/collections.rs
+++ b/src/formatting/collections.rs
@@ -50,6 +50,8 @@ impl<'a> Formatter<'a> {
             self.write("]");
         } else {
             self.write("[");
+            let first_item_start = self.list_item_bounds(&items[0]).0;
+            self.write_inline_comment_bounded(span.start.saturating_add(1), Some(first_item_start));
             self.newline();
             self.indent_level += 1;
             let closing_bracket_pos = span.end.saturating_sub(1);

--- a/src/formatting/collections.rs
+++ b/src/formatting/collections.rs
@@ -33,7 +33,8 @@ impl<'a> Formatter<'a> {
         let should_preserve_multiline = source_has_newline && items.len() > 1;
         let should_inline = !has_comments_in_list
             && (inline_single_item
-                || (all_simple && items.len() <= 5 && !should_preserve_multiline));
+                || (all_simple && items.len() <= 5 && !should_preserve_multiline))
+            && self.inline_list_fits_on_line(items, uses_commas);
 
         if should_inline {
             self.write("[");
@@ -195,6 +196,20 @@ impl<'a> Formatter<'a> {
 
         let inner = &trimmed[1..trimmed.len() - 1];
         inner.starts_with(b"-")
+    }
+
+    fn inline_list_fits_on_line(&self, items: &[ListItem], uses_commas: bool) -> bool {
+        let mut total_len = 2; // for [ and ]
+        for (i, item) in items.iter().enumerate() {
+            let item_len = self.probe_format(|p| p.format_list_item(item)).len();
+            total_len += item_len;
+            if i > 0 {
+                total_len += if uses_commas { 2 } else { 1 }; // separator
+            }
+        }
+
+        let indent_len = self.config.indent * self.indent_level;
+        indent_len + total_len <= self.config.line_length
     }
 
     fn paired_list_items_fit_on_line(

--- a/src/formatting/collections.rs
+++ b/src/formatting/collections.rs
@@ -15,7 +15,7 @@ impl<'a> Formatter<'a> {
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Format a list expression, choosing inline or multiline layout.
-    pub(super) fn format_list(&mut self, items: &[ListItem]) {
+    pub(super) fn format_list(&mut self, items: &[ListItem], span: Span) {
         if items.is_empty() {
             self.write("[]");
             return;
@@ -23,6 +23,7 @@ impl<'a> Formatter<'a> {
 
         let uses_commas = self.list_uses_commas(items);
         let source_has_newline = self.list_has_source_newline(items);
+        let has_comments_in_list = self.has_comments_in_span(span.start, span.end);
 
         let all_simple = items.iter().all(|item| match item {
             ListItem::Item(expr) | ListItem::Spread(_, expr) => self.is_simple_expr(expr),
@@ -30,8 +31,9 @@ impl<'a> Formatter<'a> {
 
         let inline_single_item = items.len() == 1 && all_simple;
         let should_preserve_multiline = source_has_newline && items.len() > 1;
-        let should_inline =
-            inline_single_item || (all_simple && items.len() <= 5 && !should_preserve_multiline);
+        let should_inline = !has_comments_in_list
+            && (inline_single_item
+                || (all_simple && items.len() <= 5 && !should_preserve_multiline));
 
         if should_inline {
             self.write("[");
@@ -50,15 +52,21 @@ impl<'a> Formatter<'a> {
             self.write("[");
             self.newline();
             self.indent_level += 1;
+            let closing_bracket_pos = span.end.saturating_sub(1);
 
             let mut idx = 0;
             while idx < items.len() {
+                let (item_start, _) = self.list_item_bounds(&items[idx]);
+                self.write_comments_before(item_start);
                 self.write_indent();
 
                 if idx + 1 < items.len() {
                     let current = &items[idx];
                     let next = &items[idx + 1];
                     if self.should_pair_flag_value_items(current, next)
+                        && !self.list_item_has_inline_comment(current, Some(closing_bracket_pos))
+                        && !self.list_item_has_inline_comment(next, Some(closing_bracket_pos))
+                        && !self.list_items_have_comments_between(current, next)
                         && self.paired_list_items_fit_on_line(current, next, uses_commas)
                     {
                         self.format_list_item(current);
@@ -68,6 +76,9 @@ impl<'a> Formatter<'a> {
                             self.write(" ");
                         }
                         self.format_list_item(next);
+                        let (_, next_end) = self.list_item_bounds(next);
+                        self.write_inline_comment_bounded(next_end, Some(closing_bracket_pos));
+                        self.last_pos = self.last_pos.max(next_end);
                         self.newline();
                         idx += 2;
                         continue;
@@ -75,10 +86,14 @@ impl<'a> Formatter<'a> {
                 }
 
                 self.format_list_item(&items[idx]);
+                let (_, item_end) = self.list_item_bounds(&items[idx]);
+                self.write_inline_comment_bounded(item_end, Some(closing_bracket_pos));
+                self.last_pos = self.last_pos.max(item_end);
                 self.newline();
                 idx += 1;
             }
 
+            self.write_comments_before(closing_bracket_pos);
             self.indent_level -= 1;
             self.write_indent();
             self.write("]");
@@ -139,6 +154,25 @@ impl<'a> Formatter<'a> {
 
     fn should_pair_flag_value_items(&self, current: &ListItem, next: &ListItem) -> bool {
         self.list_item_is_flag_string(current) && !self.list_item_is_flag_string(next)
+    }
+
+    fn list_items_have_comments_between(&self, current: &ListItem, next: &ListItem) -> bool {
+        let (_, current_end) = self.list_item_bounds(current);
+        let (next_start, _) = self.list_item_bounds(next);
+        self.has_comments_in_span(current_end, next_start)
+    }
+
+    fn list_item_has_inline_comment(&self, item: &ListItem, upper: Option<usize>) -> bool {
+        let (_, item_end) = self.list_item_bounds(item);
+        let line_end = self.source[item_end..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map_or(self.source.len(), |p| item_end + p);
+        let effective_end = upper.map_or(line_end, |u| u.min(line_end));
+
+        self.comments.iter().enumerate().any(|(i, (span, _))| {
+            !self.written_comments[i] && span.start >= item_end && span.start < effective_end
+        })
     }
 
     fn list_item_is_flag_string(&self, item: &ListItem) -> bool {

--- a/src/formatting/expressions.rs
+++ b/src/formatting/expressions.rs
@@ -92,7 +92,7 @@ impl<'a> Formatter<'a> {
                 self.format_subexpression(*block_id, expr.span);
             }
 
-            Expr::List(items) => self.format_list(items),
+            Expr::List(items) => self.format_list(items, expr.span),
             Expr::Record(items) => self.format_record(items, expr.span),
             Expr::Table(table) => self.format_table(&table.columns, &table.rows),
 

--- a/src/formatting/mod.rs
+++ b/src/formatting/mod.rs
@@ -135,11 +135,14 @@ impl<'a> Formatter<'a> {
         if self.at_line_start {
             match self.config.indent_char {
                 IndentChar::Space => {
-                    for _ in 0..(self.config.indent * self.indent_level) {
+                    let num_spaces = self.config.indent * self.indent_level;
+                    self.output.reserve(num_spaces);
+                    for _ in 0..num_spaces {
                         self.output.push(b' ');
                     }
                 }
                 IndentChar::Tab => {
+                    self.output.reserve(self.indent_level);
                     for _ in 0..self.indent_level {
                         self.output.push(b'\t');
                     }

--- a/src/formatting/mod.rs
+++ b/src/formatting/mod.rs
@@ -133,13 +133,17 @@ impl<'a> Formatter<'a> {
     /// Write indentation if at the start of a line.
     pub(crate) fn write_indent(&mut self) {
         if self.at_line_start {
-            let indent_len = self.config.indent * self.indent_level;
-            let indent_char = match self.config.indent_char {
-                IndentChar::Space => b' ',
-                IndentChar::Tab => b'\t',
-            };
-            for _ in 0..indent_len {
-                self.output.push(indent_char);
+            match self.config.indent_char {
+                IndentChar::Space => {
+                    for _ in 0..(self.config.indent * self.indent_level) {
+                        self.output.push(b' ');
+                    }
+                }
+                IndentChar::Tab => {
+                    for _ in 0..self.indent_level {
+                        self.output.push(b'\t');
+                    }
+                }
             }
             self.at_line_start = false;
         }

--- a/src/formatting/mod.rs
+++ b/src/formatting/mod.rs
@@ -21,7 +21,7 @@ mod expressions;
 mod garbage;
 mod repair;
 
-use crate::config::Config;
+use crate::config::{Config, IndentChar};
 use crate::format_error::FormatError;
 use log::{debug, trace};
 use nu_parser::parse;
@@ -133,8 +133,14 @@ impl<'a> Formatter<'a> {
     /// Write indentation if at the start of a line.
     pub(crate) fn write_indent(&mut self) {
         if self.at_line_start {
-            let indent = " ".repeat(self.config.indent * self.indent_level);
-            self.output.extend(indent.as_bytes());
+            let indent_len = self.config.indent * self.indent_level;
+            let indent_char = match self.config.indent_char {
+                IndentChar::Space => b' ',
+                IndentChar::Tab => b'\t',
+            };
+            for _ in 0..indent_len {
+                self.output.push(indent_char);
+            }
             self.at_line_start = false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,7 @@ mod tests {
 
     #[rstest]
     #[case(r#"{line_length: 120, exclude: ["a*nu", "b*.nu"]}"#)]
+    #[case(r#"{indent_char: "tab", line_length: 120}"#)]
     fn read_valid_config(#[case] config_content: &str) {
         let dir = tempdir().unwrap();
         let config_file = dir.path().join("nufmt.nuon");
@@ -478,7 +479,12 @@ mod tests {
 
         let config = read_config(&config_file).expect("Config should be valid");
         assert_eq!(config.line_length, 120_usize);
-        assert_eq!(config.excludes.len(), 2_usize);
+        if config_content.contains("exclude") {
+            assert_eq!(config.excludes.len(), 2_usize);
+        }
+        if config_content.contains(r#"indent_char: "tab""#) {
+            assert_eq!(config.indent_char, nu_formatter::config::IndentChar::Tab);
+        }
     }
 
     #[rstest]
@@ -488,6 +494,8 @@ mod tests {
     #[case(r#"{line_length: "120"}"#)]
     #[case(r#"{exclude: "a*nu"}"#)]
     #[case(r#"{exclude: ["a*nu", 1]}"#)]
+    #[case(r#"{indent_char: 1}"#)]
+    #[case(r#"{indent_char: "tabs"}"#)]
     fn read_invalid_config(#[case] config_content: &str) {
         let dir = tempdir().unwrap();
         let config_file = dir.path().join("nufmt.nuon");

--- a/tests/fixtures/config/indentation_respects_line_length.nuon
+++ b/tests/fixtures/config/indentation_respects_line_length.nuon
@@ -1,0 +1,5 @@
+{
+indent_char: "space"
+indent: 20
+line_length: 40
+}

--- a/tests/fixtures/config/tab_indentation_via_config_issue196.nuon
+++ b/tests/fixtures/config/tab_indentation_via_config_issue196.nuon
@@ -1,5 +1,5 @@
 {
-    indent: 1
+    indent: 4
     indent_char: "tab"
     line_length: 80
     margin: 1

--- a/tests/fixtures/config/tab_indentation_via_config_issue196.nuon
+++ b/tests/fixtures/config/tab_indentation_via_config_issue196.nuon
@@ -1,0 +1,6 @@
+{
+    indent: 1
+    indent_char: "tab"
+    line_length: 80
+    margin: 1
+}

--- a/tests/fixtures/expected/indentation_respects_line_length.nu
+++ b/tests/fixtures/expected/indentation_respects_line_length.nu
@@ -1,0 +1,13 @@
+def test [] {
+                    {
+                                        (echo
+                                                            abv
+                                                            def
+                                                            fef
+                                                            faei
+                                                            feal
+                                                            afea
+                                                            abcdefgh
+                                        )
+                    }
+}

--- a/tests/fixtures/expected/side_comments_in_multiline_lists_preserved_issue195.nu
+++ b/tests/fixtures/expected/side_comments_in_multiline_lists_preserved_issue195.nu
@@ -1,4 +1,5 @@
 let flags = [
+    # opener-side comment should survive
     "--name" # keep this side comment
     "alice" # and this one too
     # keep this standalone comment
@@ -8,4 +9,11 @@ let flags = [
 
 let single = [
     1 # keep single-item side comment
+]
+
+const SIT = [ # SUPPORTED_INSTALLATION_TYPES
+    'cargo-git'
+    'crate'
+    'git-module'
+    'git-script'
 ]

--- a/tests/fixtures/expected/side_comments_in_multiline_lists_preserved_issue195.nu
+++ b/tests/fixtures/expected/side_comments_in_multiline_lists_preserved_issue195.nu
@@ -1,0 +1,11 @@
+let flags = [
+    "--name" # keep this side comment
+    "alice" # and this one too
+    # keep this standalone comment
+    "--age"
+    42 # keep numeric side comment
+]
+
+let single = [
+    1 # keep single-item side comment
+]

--- a/tests/fixtures/expected/tab_indentation_via_config_issue196.nu
+++ b/tests/fixtures/expected/tab_indentation_via_config_issue196.nu
@@ -1,0 +1,7 @@
+def greet [name] {
+	if $name != "" {
+		print $"Hello ($name)"
+	} else {
+		print "Hello"
+	}
+}

--- a/tests/fixtures/input/indentation_respects_line_length.nu
+++ b/tests/fixtures/input/indentation_respects_line_length.nu
@@ -1,0 +1,5 @@
+def test [] {
+{
+echo abv def fef faei feal afea abcdefgh
+}
+}

--- a/tests/fixtures/input/side_comments_in_multiline_lists_preserved_issue195.nu
+++ b/tests/fixtures/input/side_comments_in_multiline_lists_preserved_issue195.nu
@@ -1,4 +1,5 @@
 let flags = [
+  # opener-side comment should survive
   "--name" # keep this side comment
   "alice" # and this one too
   # keep this standalone comment
@@ -8,4 +9,11 @@ let flags = [
 
 let single = [
   1 # keep single-item side comment
+]
+
+const SIT = [ # SUPPORTED_INSTALLATION_TYPES
+  'cargo-git',
+  'crate',
+  'git-module',
+  'git-script'
 ]

--- a/tests/fixtures/input/side_comments_in_multiline_lists_preserved_issue195.nu
+++ b/tests/fixtures/input/side_comments_in_multiline_lists_preserved_issue195.nu
@@ -1,0 +1,11 @@
+let flags = [
+  "--name" # keep this side comment
+  "alice" # and this one too
+  # keep this standalone comment
+  "--age"
+  42 # keep numeric side comment
+]
+
+let single = [
+  1 # keep single-item side comment
+]

--- a/tests/fixtures/input/tab_indentation_via_config_issue196.nu
+++ b/tests/fixtures/input/tab_indentation_via_config_issue196.nu
@@ -1,0 +1,7 @@
+def greet [name] {
+  if $name != "" {
+    print $"Hello ($name)"
+  } else {
+    print "Hello"
+  }
+}

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -570,6 +570,11 @@ fixture_tests!(
         idempotency_comment_spacing_before_toplevel_statements_issue150
     ),
     (
+        "side_comments_in_multiline_lists_preserved_issue195",
+        ground_truth_side_comments_in_multiline_lists_preserved_issue195,
+        idempotency_side_comments_in_multiline_lists_preserved_issue195
+    ),
+    (
         "list_flag_value_pairing_preserved_issue151",
         ground_truth_list_flag_value_pairing_preserved_issue151,
         idempotency_list_flag_value_pairing_preserved_issue151
@@ -698,5 +703,10 @@ fixture_tests!(
         "match_arm_formatting_is_idempotent_issue189",
         ground_truth_match_arm_formatting_is_idempotent_issue189,
         idempotency_match_arm_formatting_is_idempotent_issue189
+    ),
+    (
+        "tab_indentation_via_config_issue196",
+        ground_truth_tab_indentation_via_config_issue196,
+        idempotency_tab_indentation_via_config_issue196
     ),
 );


### PR DESCRIPTION
## Description of changes

Add the ability to have tabs or spaces in formatting.
- Added indent_char config support with values "space" (default) and "tab".

Fix the side-comments bug
- Fixed multiline list formatting so side/inline comments are preserved.
- Lists containing comments are now kept multiline, comments before items are emitted correctly, inline comments after list items are retained, and list flag/value pairing is skipped when comments would be affected.


## Relevant Issues

closes #195 
closes #196 
