### PR TITLE
Track single-quoted strings and skip comments when detecting missing record commas

### DIFF
--- a/src/formatting/repair.rs
+++ b/src/formatting/repair.rs
@@ -194,18 +194,44 @@ pub(super) fn try_repair_compact_if_else(source: &str) -> (String, bool) {
 /// Detect byte positions where a comma is likely missing between record fields.
 fn detect_missing_record_comma_positions(source: &str) -> Vec<usize> {
     let bytes = source.as_bytes();
+    // Comments are extracted with their own string-aware scan (see
+    // `comments::extract_comments`) so a `#` inside a string literal is never
+    // mistaken for a comment start. We reuse those spans here to skip over
+    // comment bodies entirely: an apostrophe inside a comment (e.g. "don't",
+    // "it's") must never be mistaken for the start of a single-quoted string,
+    // or quote-parity tracking below desyncs for the rest of the file.
+    let comment_spans = super::comments::extract_comments(bytes);
+    let mut comments = comment_spans.iter();
+    let mut next_comment = comments.next();
+
     let mut in_string = false;
+    let mut in_single_string = false;
     let mut escaped = false;
     let mut insert_positions: Vec<usize> = Vec::new();
 
-    for (idx, &byte) in bytes.iter().enumerate() {
+    let mut idx = 0;
+    while idx < bytes.len() {
+        let byte = bytes[idx];
+
+        // Single-quoted strings are raw in nushell: no escapes, and a `"` inside
+        // them must not toggle the double-quote tracking below.
+        if in_single_string {
+            if byte == b'\'' {
+                in_single_string = false;
+            }
+            idx += 1;
+            continue;
+        }
+
         if in_string {
             if escaped {
                 escaped = false;
+                idx += 1;
                 continue;
             }
             if byte == b'\\' {
                 escaped = true;
+                idx += 1;
                 continue;
             }
             if byte == b'"' {
@@ -237,13 +263,38 @@ fn detect_missing_record_comma_positions(source: &str) -> Vec<usize> {
                     }
                 }
             }
+            idx += 1;
             continue;
+        }
+
+        // Drop any comment spans we've already passed (defensive; should not
+        // normally trigger since both scans walk left-to-right in lockstep).
+        while let Some((span, _)) = next_comment {
+            if span.end <= idx {
+                next_comment = comments.next();
+            } else {
+                break;
+            }
+        }
+
+        // Not inside any string: a `#` here starts a line comment. Skip its
+        // whole body so apostrophes/quotes inside it are never tracked.
+        if let Some((span, _)) = next_comment {
+            if span.start == idx {
+                idx = span.end;
+                next_comment = comments.next();
+                continue;
+            }
         }
 
         if byte == b'"' {
             in_string = true;
             escaped = false;
+        } else if byte == b'\'' {
+            in_single_string = true;
         }
+
+        idx += 1;
     }
 
     insert_positions

--- a/tests/fixtures/expected/comment_apostrophe_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/expected/comment_apostrophe_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,5 @@
+def main [] {
+    # don't
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/expected/mid_file_comment_apostrophe_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/expected/mid_file_comment_apostrophe_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,6 @@
+def main [] {
+    # don't
+
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/expected/multiple_apostrophes_in_comment_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/expected/multiple_apostrophes_in_comment_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,5 @@
+def main [] {
+    # it's John's, don't
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/expected/single_quoted_double_quote_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/expected/single_quoted_double_quote_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,4 @@
+def main [] {
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/input/comment_apostrophe_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/input/comment_apostrophe_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,5 @@
+def main [] {
+    # don't
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/input/mid_file_comment_apostrophe_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/input/mid_file_comment_apostrophe_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,6 @@
+def main [] {
+    # don't
+
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/input/multiple_apostrophes_in_comment_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/input/multiple_apostrophes_in_comment_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,5 @@
+def main [] {
+    # it's John's, don't
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/fixtures/input/single_quoted_double_quote_does_not_break_interpolation_issue201.nu
+++ b/tests/fixtures/input/single_quoted_double_quote_does_not_break_interpolation_issue201.nu
@@ -1,0 +1,4 @@
+def main [] {
+    let x = '"'
+    print $"Hello: ($x)"
+}

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -709,4 +709,24 @@ fixture_tests!(
         ground_truth_tab_indentation_via_config_issue196,
         idempotency_tab_indentation_via_config_issue196
     ),
+    (
+        "single_quoted_double_quote_does_not_break_interpolation_issue201",
+        ground_truth_single_quoted_double_quote_does_not_break_interpolation_issue201,
+        idempotency_single_quoted_double_quote_does_not_break_interpolation_issue201
+    ),
+    (
+        "comment_apostrophe_does_not_break_interpolation_issue201",
+        ground_truth_comment_apostrophe_does_not_break_interpolation_issue201,
+        idempotency_comment_apostrophe_does_not_break_interpolation_issue201
+    ),
+    (
+        "mid_file_comment_apostrophe_does_not_break_interpolation_issue201",
+        ground_truth_mid_file_comment_apostrophe_does_not_break_interpolation_issue201,
+        idempotency_mid_file_comment_apostrophe_does_not_break_interpolation_issue201
+    ),
+    (
+        "multiple_apostrophes_in_comment_does_not_break_interpolation_issue201",
+        ground_truth_multiple_apostrophes_in_comment_does_not_break_interpolation_issue201,
+        idempotency_multiple_apostrophes_in_comment_does_not_break_interpolation_issue201
+    ),
 );


### PR DESCRIPTION
## Description of changes

`detect_missing_record_comma_positions` tracked double-quote string state but not single-quoted strings, so a `"` inside a `'...'` literal (e.g. `let x = '"'`) desynced the parser's quote tracking and caused a spurious comma to be inserted into a later `$"..."` interpolation.

This adds single-quote string tracking, and also skips `#` comment bodies during the same scan (reusing the existing comment extraction from comments.rs) so an apostrophe inside a comment like `# don't` can't be mistaken for the start of a single-quoted string and desync things the same way.

## Relevant Issues

Fixes #201
