### PR TITLE
chore: add nix metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,13 @@
             })
           ];
           cargoLock.lockFile = ./Cargo.lock;
+
+          meta = {
+            description = "A formatter for Nushell scripts, built entirely on Nushell's own parsing infrastructure";
+            homepage = "https://github.com/nushell/nufmt";
+            license = inputs.nixpkgs.lib.licenses.mit;
+            mainProgram = "nufmt";
+          };
         };
 
         formatter = inputs.treefmt-nix.lib.mkWrapper pkgs {


### PR DESCRIPTION
## Description of changes

Added metadata for the nix package to allow easier usage in regards to the `getExe` function.
The following evaluation warning is fixed with this change.
```
evaluation warning: getExe: Package nufmt does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```

## Relevant Issues

None.
