### PR TITLE
Preserve comments at the end of multiline pipeline

### DIFF
--- a/src/formatting/blocks.rs
+++ b/src/formatting/blocks.rs
@@ -283,6 +283,17 @@ impl<'a> Formatter<'a> {
                 }
             }
             self.format_pipeline_element(element);
+
+            if let Some(next) = pipeline.elements.get(i + 1) {
+                let end_pos = self.get_element_end_pos(element);
+                let next_start = next.expr.span.start;
+                self.write_inline_comment_bounded(end_pos, Some(next_start));
+                self.last_pos = self.last_pos.max(end_pos);
+
+                if is_multiline {
+                    self.write_comments_before(next_start);
+                }
+            }
         }
     }
 

--- a/tests/fixtures/expected/multiline_pipeline_inline_comment_preserved.nu
+++ b/tests/fixtures/expected/multiline_pipeline_inline_comment_preserved.nu
@@ -1,0 +1,3 @@
+open ./non-exist.json # comment about this line
+| to json
+| save ./new.json

--- a/tests/fixtures/input/multiline_pipeline_inline_comment_preserved.nu
+++ b/tests/fixtures/input/multiline_pipeline_inline_comment_preserved.nu
@@ -1,0 +1,3 @@
+open ./non-exist.json # comment about this line
+  | to json
+ | save ./new.json

--- a/tests/ground_truth.rs
+++ b/tests/ground_truth.rs
@@ -265,6 +265,11 @@ fixture_tests!(
         ground_truth_multiline_pipeline,
         idempotency_multiline_pipeline
     ),
+    (
+        "multiline_pipeline_inline_comment_preserved",
+        ground_truth_multiline_pipeline_inline_comment_preserved,
+        idempotency_multiline_pipeline_inline_comment_preserved
+    ),
     ("closure", ground_truth_closure, idempotency_closure),
     (
         "subexpression",


### PR DESCRIPTION
## Description of changes

<!-- What changes did you make -->

Make the formatter dont delete inline comments between a multiline pipeline statement.

Previously, when there are inline comments at the end of a line in multiline pipeline, the comments get removed when the formatter run, which is probably not the desired behavior.

See the new test case for more detail. 

## Relevant Issues

<!-- Eg. #43 -->

N/A.